### PR TITLE
feat(ios): show build operation duration in Xcode toolbar

### DIFF
--- a/setup/ios.sh
+++ b/setup/ios.sh
@@ -182,6 +182,14 @@ defaults -currentHost write com.apple.ImageCapture disableHotPlug -bool true
 defaults write com.apple.messageshelper.MessageController SOInputLineSettings -dict-add "automaticQuoteSubstitutionEnabled" -bool false
 
 
+###############################################################################
+# Xcode                                                                       #
+###############################################################################
+# Show the build operation duration in the toolbar
+defaults write com.apple.dt.Xcode ShowBuildOperationDuration -bool true
+
+
+killall Xcode
 killall Contacts
 killall Calendar
 killall Messages


### PR DESCRIPTION
Enabled the `ShowBuildOperationDuration` setting for Xcode in the iOS setup script and added a `killall Xcode` command to apply the changes.

---
*PR created automatically by Jules for task [15064492163178226198](https://jules.google.com/task/15064492163178226198) started by @AlonsoFloo*