### PR TITLE
feat: Restrict brew execution and update sudo prompt

### DIFF
--- a/setup/common.sh
+++ b/setup/common.sh
@@ -4,9 +4,9 @@
 if [[ -z "$USE_SUDO_PROMPTED" ]]; then
 	export USE_SUDO="no"
 	if [[ "$1" != "--quiet" ]]; then
-		echo "Do you want to use sudo for installation? (yes/no) "
+		echo "Do you want to use sudo for installation? (Y/n) "
 		read -r user_sudo
-		if [[ "$user_sudo" =~ ^[Yy](es)?$ ]]; then
+		if [[ -z "$user_sudo" ]] || [[ "$user_sudo" =~ ^[Yy](es)?$ ]]; then
 			export USE_SUDO="yes"
 		fi
 	fi

--- a/setup/common.sh
+++ b/setup/common.sh
@@ -22,18 +22,18 @@ execute_with_sudo() {
 }
 
 #setting links
-for file in ${DOTFILE_PATH}{bash_logout,bashrc,bash_profile,zshrc,zlogout,inputrc,gitconfig,vimrc,vim,config,ssh}; do
-	file="$( basename $file )"
+for file in "${DOTFILE_PATH}"{bash_logout,bashrc,bash_profile,zshrc,zlogout,inputrc,gitconfig,vimrc,vim,config,ssh}; do
+	file="$( basename "$file" )"
 
-	if [[ ! -h ~/.${file} ]] && [[ -d ~/.${file} ]]; then
-		cp -rn ~/.${file}/* ${DOTFILE_PATH}${file}/
+	if [[ ! -h ~/."${file}" ]] && [[ -d ~/."${file}" ]]; then
+		cp -rn ~/."${file}"/* "${DOTFILE_PATH}""${file}"/
 	fi
 
-	if [[ -h ~/.${file} ]]; then
-		rm -f ~/.${file}
-	elif [[ -e ~/.${file} ]]; then
-		mv ~/.${file} ~/.${file}.dotfiles.bak
+	if [[ -h ~/."${file}" ]]; then
+		rm -f ~/."${file}"
+	elif [[ -e ~/."${file}" ]]; then
+		mv ~/."${file}" ~/."${file}".dotfiles.bak
 	fi
 
-	ln -sf ${DOTFILE_PATH}${file} ~/.${file}
+	ln -sf "${DOTFILE_PATH}""${file}" ~/."${file}"
 done;

--- a/setup/ios.sh
+++ b/setup/ios.sh
@@ -8,11 +8,15 @@ if [[ ! "$(which brew)" ]]; then
 fi
 
 if [[ "$(which brew)" ]]; then
-	brew update
-	brew upgrade
+	if [[ "$USE_SUDO" == "yes" ]]; then
+		brew update
+		brew upgrade
 
-	# Check BrewFile at root folder
-	brew bundle check || brew bundle install
+		# Check BrewFile at root folder
+		brew bundle check || brew bundle install
+	else
+		echo "Sudo is disabled. Skipping Homebrew update/upgrade/bundle."
+	fi
 fi
 
 


### PR DESCRIPTION
Restrict Homebrew operations in `setup/ios.sh` to only run when sudo is enabled, as requested. Additionally, updated the sudo confirmation prompt in `setup/common.sh` to the `(Y/n)` format, where empty input defaults to 'yes'.

---
*PR created automatically by Jules for task [5487221154872452520](https://jules.google.com/task/5487221154872452520) started by @AlonsoFloo*